### PR TITLE
Fix energy equation in Notebook 5

### DIFF
--- a/5-simple-image-filtering.ipynb
+++ b/5-simple-image-filtering.ipynb
@@ -1599,7 +1599,7 @@
    "source": [
     "One way to assess sets of filtered images like these is to contrast the *energy* content. In this context, the energy `E` of an image `X` is given by the sum of the squares of the individual pixel values:\n",
     "```python\n",
-    "E = np.sum(X**2)\n",
+    "E = np.sum(X**2.0)\n",
     "```\n",
     "Remember that $a^b$ is spelt `a**b` in Python, not `a^b`!"
    ]


### PR DESCRIPTION
As noted by @eric-wieser , using `np.sum(X**2)` to calculate the energy of the image `X` gives an incorrect result because the elements of `X` are of type `np.uint8`, so they overflow:

![energy_error](https://user-images.githubusercontent.com/45038919/118481555-221c5880-b703-11eb-8864-d4714fd310ab.png)

This can be quite confusing when comparing the energy of the original image and the filtered versions, as the filtered images have elements of type `np.float64` so they don't overflow, which makes the comparison useless.

It might be useful to fix this by using `np.sum(X**2.0)` so that students don't get confused.